### PR TITLE
Fix sources filepath in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(sfml_pendulumPhysics)
 set(CMAKE_CXX_STANDARD 14)
 
 
-set(SOURCES src/main.cpp src/Pendulum.cpp)
+set(SOURCES src/Main.cpp src/Pendulum.cpp)
 add_executable(${PROJECT_NAME} ${SOURCES})
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "a")
 


### PR DESCRIPTION
When following the steps to build the project based on README.md, **cmake** raises an error:

![Screenshot_20220606_012247](https://user-images.githubusercontent.com/59486112/172094497-5b949680-00af-43de-a3d9-780002931535.png)

The fix for this is update CMakeLists.txt or rename the file `Main.cpp` to `main.cpp`. As the other files in the project, I believe that maintain the _Pascal Case_ is the most correct.
